### PR TITLE
player-rankings-3

### DIFF
--- a/client/src/components/landing-page/components/fantasy-tracker-lp.jsx
+++ b/client/src/components/landing-page/components/fantasy-tracker-lp.jsx
@@ -28,7 +28,7 @@ function FantasyTrackerLP () {
       if (err) {
         console.log('error', err)
       } else {
-        console.log('worked', res.data);
+        console.log('fantasy tracker data', res.data);
         setMatchupMetaData(res.data);
         var ids = {};
         // create an object of key values pairs of id to name

--- a/client/src/components/landing-page/components/player-ranking-lp.jsx
+++ b/client/src/components/landing-page/components/player-ranking-lp.jsx
@@ -27,7 +27,8 @@ import { data, images } from "./mock-data/lp-data.js"
 // investigation #2, the above gives us what we are looking for in terms of only waiver players and their averages
 // we need to find out our daily leaders for the current scoring period which can be found using
 // {"players":{"filterStatus":{"value":["FREEAGENT","WAIVERS"]},"filterSlotIds":{"value":[0,5,11,1,2,6,3,4]},"sortAppliedStatTotal":null,"sortAppliedStatTotalForScoringPeriodId":null,"sortStatId":{"additionalValue":"002022","sortAsc":false,"sortPriority":2,"value":0},"sortStatIdForScoringPeriodId":null,"sortPercOwned":{"sortPriority":3,"sortAsc":false},"limit":50,"filterStatsForTopScoringPeriodIds":{"value":5,"additionalValue":["002023","102023","002022","012023","022023","032023","042023"]}}}
-// I believe null for the scoring period gives the scoring period thats most recent? Need more investigation
+// I believe the filter for top scoring period ids gives us the 5 most recent scoring periods
+// need to do investigation on this
 
 
 function PlayerRankingLP () {

--- a/client/src/components/landing-page/components/player-ranking-lp.jsx
+++ b/client/src/components/landing-page/components/player-ranking-lp.jsx
@@ -1,6 +1,8 @@
 // player ranking section for our landing-page
 // watch list carousel for our landing page.
-
+const axios = require('axios');
+// import dotenv variables for this section
+import {PROXY_URL, REACT_APP_SEASON, REACT_APP_LEAGUE, REACT_APP_SWID, REACT_APP_ESPN} from "@env"
 // react imports
 import React, { useState, useEffect } from "react";
 // global styles for bootstrap
@@ -17,11 +19,16 @@ import { data, images } from "./mock-data/lp-data.js"
 // should we pre-sort by categories to start?
 // could we do that in a database query to start with?
 
-
 // idea: we can filter out the players already on a roster
 // we ping for the player_kona_info and use the header x-fantasy-filter
 // this allows us to filter by fantasy leage and our value should be the JSON string of
 // {"players":{"filterStatus":{"value":["FREEAGENT","WAIVERS"]},"limit":2000,"sortPercOwned":{"sortAsc":false,"sortPriority":1}}}
+
+// investigation #2, the above gives us what we are looking for in terms of only waiver players and their averages
+// we need to find out our daily leaders for the current scoring period which can be found using
+// {"players":{"filterStatus":{"value":["FREEAGENT","WAIVERS"]},"filterSlotIds":{"value":[0,5,11,1,2,6,3,4]},"sortAppliedStatTotal":null,"sortAppliedStatTotalForScoringPeriodId":null,"sortStatId":{"additionalValue":"002022","sortAsc":false,"sortPriority":2,"value":0},"sortStatIdForScoringPeriodId":null,"sortPercOwned":{"sortPriority":3,"sortAsc":false},"limit":50,"filterStatsForTopScoringPeriodIds":{"value":5,"additionalValue":["002023","102023","002022","012023","022023","032023","042023"]}}}
+// I believe null for the scoring period gives the scoring period thats most recent? Need more investigation
+
 
 function PlayerRankingLP () {
 
@@ -31,6 +38,14 @@ function PlayerRankingLP () {
   useEffect( () => {
     // here we make a call to our cors-proxy api
     // we want to get all our player infomation for the waiver wire
+    axios.get(`${PROXY_URL}` )
+    .then( (result, err) => {
+      if (err) {
+        console.log('error', err)
+      } else {
+        console.log('result', result.data)
+      }
+    })
   })
 
   // update pageIndex here

--- a/client/src/components/landing-page/components/player-ranking-lp.jsx
+++ b/client/src/components/landing-page/components/player-ranking-lp.jsx
@@ -28,6 +28,10 @@ function PlayerRankingLP () {
   // useState here
   const [pageIndex, setPageIndex] = useState(1);
   // useEffect here
+  useEffect( () => {
+    // here we make a call to our cors-proxy api
+    // we want to get all our player infomation for the waiver wire
+  })
 
   // update pageIndex here
   function updatePageIndex (e) {

--- a/client/src/components/landing-page/components/watchlist-lp.jsx
+++ b/client/src/components/landing-page/components/watchlist-lp.jsx
@@ -82,7 +82,9 @@ function WatchlistLP () {
                             <img style={{minWidth: "100%", maxHeight: "100%", border: "solid black 3px", padding: "0"}} src={images.image}></img>
                           </Row>
                           <Row style={{border: "solid orange 3px", height: "20%"}}>
-                            <Col style={{border: "solid blue 3px", padding: "12", maxHeight: "99%"}}> {data[index].player.first_name} {data[index].player.last_name} </Col>
+                            <Col style={{border: "solid blue 3px", padding: "12", maxHeight: "99%"}}>
+                              <div style={{overflowY: "scroll", maxHeight: "99%"}}> {data[index].player.first_name} {data[index].player.last_name} </div>
+                            </Col>
                           </Row>
                       </Col>
                       )


### PR DESCRIPTION
Investigation of ESPN API making head way. It is more and more likely that we will need to wait until the start of the season to figure out which x-fantasty-filter tags we can properly use to return live stat data for daily player rankings. Using dev tools, we can utilize the network tab and kona_player_info to locate which requests the ESPN app is sending and dive deep into the exact filter format to return the data. Will use mock data for now to continue to develop frontend. 